### PR TITLE
fix datepicker so that it works with Darwin, and possibly fix stack overwrite

### DIFF
--- a/examples/flight-booker.zig
+++ b/examples/flight-booker.zig
@@ -186,9 +186,8 @@ const App = struct {
             const leave_date = app.leave_date orelse break :enable_book;
             const return_date = app.return_date orelse break :enable_book;
 
-            if (leave_date.year <= return_date.year and
-                leave_date.month <= return_date.month and
-                leave_date.month_day < return_date.month_day)
+            if ((leave_date.year < return_date.year) or
+                (leave_date.year == return_date.year and leave_date.year_day <= return_date.year_day))
             {
                 app.return_status.SetText("");
                 app.book.as_control().Enable();

--- a/examples/flight-booker.zig
+++ b/examples/flight-booker.zig
@@ -17,7 +17,7 @@ pub fn main() !void {
     };
     defer ui.Uninit();
 
-    const main_window = try ui.Window.New("Hello, World!", 320, 240, .hide_menubar);
+    const main_window = try ui.Window.New("Fly with IguanaAir", 320, 240, .hide_menubar);
     const vbox = try ui.Box.New(.Vertical);
 
     var app = App{
@@ -183,7 +183,7 @@ const App = struct {
         }
 
         enable_book: {
-            const leave_date = app.leave_date orelse break :enable_book;
+            const leave_date = app.leave_date orelse app.leave_datetime.Time();
             const return_date = app.return_date orelse break :enable_book;
 
             if ((leave_date.year < return_date.year) or

--- a/src/extras.zig
+++ b/src/extras.zig
@@ -121,7 +121,7 @@ pub fn Table(comptime T: type) type {
                 .Model = self.model,
                 .RowBackgroundColorModelColumn = @intFromEnum(params.row_background),
             };
-            var table = try ui.Table.New(&ui_params);
+            const table = try ui.Table.New(&ui_params);
             return table;
         }
 

--- a/src/ui.zig
+++ b/src/ui.zig
@@ -747,7 +747,7 @@ pub const RadioButtons = opaque {
     }
 };
 
-/// Based on `struct tm` from libc `time.h`
+/// Based on `struct tm` from BSD standard `time.h`
 /// Fields have been renamed to make them clearer.
 pub const struct_tm = extern struct {
     /// Renamed from `tm_sec`.
@@ -778,12 +778,12 @@ pub const struct_tm = extern struct {
     /// Daylight Savings Time flag. The value is positive if DST is in effect, zero if not
     /// and negative if no information is available.
     is_dst: c_int = -1,
-
-    /// Sets the field `year` relative to 0 A.D.
-    /// @param year The year relative to 0 A.D.
-    pub fn with_year_AD(tm: struct_tm, year: c_int) tm {
-        tm.year = year - 1900;
-    }
+    /// Renamed from BSD standard `tm_gmtoff`
+    /// Seconds east of UTC
+    gmtoff: c_long = 0,
+    /// Renamed from BSD standard `tm_zone`
+    /// Timezone abbreviation, pointer to a C string
+    zone: [*c]const u8 = undefined,
 };
 
 /// DateTimePicker is a control that allows the user to select a date and/or time.
@@ -811,11 +811,10 @@ pub const DateTimePicker = opaque {
 
     // pub const Time = uiDateTimePickerTime;
     pub fn Time(d: *DateTimePicker) struct_tm {
-        const ui_allocator = std.heap.page_allocator;
-        const tm = ui_allocator.create(struct_tm) catch return struct_tm{};
-        defer ui_allocator.destroy(tm);
-        d.uiDateTimePickerTime(tm);
-        return tm.*;
+        var tm: struct_tm = undefined;
+        d.uiDateTimePickerTime(&tm);
+        std.debug.print("new time = {any} TZ {s}\n", .{ tm, tm.zone });
+        return tm;
     }
     pub const SetTime = uiDateTimePickerSetTime;
     pub const OnChanged = uiDateTimePickerOnChanged;

--- a/src/ui.zig
+++ b/src/ui.zig
@@ -796,13 +796,11 @@ pub const struct_tm = extern struct {
 /// @warning The `struct_tm` member `is_dst` is ignored on windows and should be set to `-1`.
 ///
 /// @todo for Time: define what values are returned when a part is missing
-pub const DateTimePicker = struct {
+pub const DateTimePicker = opaque {
     const Self = @This();
     pub fn as_control(self: *Self) *Control {
         return @ptrCast(@alignCast(self));
     }
-
-    time: struct_tm = undefined,
 
     pub extern fn uiDateTimePickerTime(d: *DateTimePicker, time: *struct_tm) void;
     pub extern fn uiDateTimePickerSetTime(d: *DateTimePicker, time: *const struct_tm) void;
@@ -813,8 +811,11 @@ pub const DateTimePicker = struct {
 
     // pub const Time = uiDateTimePickerTime;
     pub fn Time(d: *DateTimePicker) struct_tm {
-        d.uiDateTimePickerTime(&d.time);
-        return d.time;
+        const ui_allocator = std.heap.page_allocator;
+        const tm = ui_allocator.create(struct_tm) catch return struct_tm{};
+        defer ui_allocator.destroy(tm);
+        d.uiDateTimePickerTime(tm);
+        return tm.*;
     }
     pub const SetTime = uiDateTimePickerSetTime;
     pub const OnChanged = uiDateTimePickerOnChanged;

--- a/src/ui.zig
+++ b/src/ui.zig
@@ -796,11 +796,13 @@ pub const struct_tm = extern struct {
 /// @warning The `struct_tm` member `is_dst` is ignored on windows and should be set to `-1`.
 ///
 /// @todo for Time: define what values are returned when a part is missing
-pub const DateTimePicker = opaque {
+pub const DateTimePicker = struct {
     const Self = @This();
     pub fn as_control(self: *Self) *Control {
         return @ptrCast(@alignCast(self));
     }
+
+    time: struct_tm = undefined,
 
     pub extern fn uiDateTimePickerTime(d: *DateTimePicker, time: *struct_tm) void;
     pub extern fn uiDateTimePickerSetTime(d: *DateTimePicker, time: *const struct_tm) void;
@@ -811,9 +813,8 @@ pub const DateTimePicker = opaque {
 
     // pub const Time = uiDateTimePickerTime;
     pub fn Time(d: *DateTimePicker) struct_tm {
-        var time: struct_tm = undefined;
-        d.uiDateTimePickerTime(&time);
-        return time;
+        d.uiDateTimePickerTime(&d.time);
+        return d.time;
     }
     pub const SetTime = uiDateTimePickerSetTime;
     pub const OnChanged = uiDateTimePickerOnChanged;
@@ -1443,7 +1444,7 @@ pub const ColorButton = opaque {
     pub extern fn uiNewColorButton() ?*ColorButton;
 
     pub fn Color(cb: *const ColorButton) ColorValue {
-        var color_value: ColorValue = undefined;
+        const color_value: ColorValue = undefined;
         uiColorButtonColor(
             cb,
             color_value.red,


### PR DESCRIPTION
Nice work !

Having some small issues running this on Mac. (haven't tested this on Linux or Win)

With the datePicker widget, zig ends up complaining about possible stack smashing, if you pass the address of a stack variable.  

In the original code, it creates a stack variable 'time', and passes the address of this to ui.DateTimePickerTime(&time). Sounds reasonable, but the compiler_rt detects possible stack smashing.

If I allocate a new one on the heap, and pass that through, that works fine (but its ugly because it allocates memory)

Alternative - if the widgets can be structs, rather than opaques .... then you can add fields to the struct, and the fields are heap allocated when widget.New() is called.  That's what I have done in this PR, and it seems to work well.

What is the requirement to have the widgets declared as opaques ?  If we can do structs instead, it still compiles and runs ok ... and the benefit of being able to add additional fields is nice.

Also for reference with the need to allocate a new struct_tm rather than pass a ref to a local variable  :  https://github.com/andlabs/ui/blob/70a69d6ae31ed9d8bb0619a191179c63d846ab8e/datetimepicker.go#L53

This is a Go wrapper around libui, and you can see in the DateTimePicker implementation, it also has to do the "allocate a new time on the heap, and pass that to the function" ... so it must be a general problem.