### PR TITLE
remove extra debugging print from dateTimePicker

### DIFF
--- a/src/ui.zig
+++ b/src/ui.zig
@@ -813,7 +813,6 @@ pub const DateTimePicker = opaque {
     pub fn Time(d: *DateTimePicker) struct_tm {
         var tm: struct_tm = undefined;
         d.uiDateTimePickerTime(&tm);
-        std.debug.print("new time = {any} TZ {s}\n", .{ tm, tm.zone });
         return tm;
     }
     pub const SetTime = uiDateTimePickerSetTime;


### PR DESCRIPTION
need to get rid of that printf, thx

currently testing that new draw widget example - had to make some changes to the C lib to get it working on Darwin as well.  Will keep playing for a few days and report back on all that.

Subjective opinion - that the Objective-C code in the old lib is getting a bit out of date, and may benefit from a major rewrite to use the latest apple libs. Just guessing, but that's what it feels like