### PR TITLE
fix: Fix `ui.Entry.SetReadOnly()` to take `bool` instead of `c_int`

### DIFF
--- a/src/ui.zig
+++ b/src/ui.zig
@@ -594,7 +594,7 @@ pub const Entry = opaque {
     pub fn ReadOnly(e: *Entry) bool {
         return uiEntryReadOnly(e) == 1;
     }
-    pub fn SetReadOnly(e: *Entry, readonly: c_int) void {
+    pub fn SetReadOnly(e: *Entry, readonly: bool) void {
         return uiEntrySetReadOnly(e, @intFromBool(readonly));
     }
     pub const TypeEnum = enum {


### PR DESCRIPTION
When porting the control gallery example (#14) I ran into the following build error:

```
% zig build
install
└─ install control-gallery
   └─ zig build-exe control-gallery Debug native 1 errors
examples/control-gallery.zig:237:33: error: expected type 'c_int', found 'bool'
    open_file_entry.SetReadOnly(true);
                                ^~~~
src/ui.zig:597:45: note: parameter type declared here
    pub fn SetReadOnly(e: *Entry, readonly: c_int) void {
                                            ^~~~~
```

This change fixes `ui.Entry.SetReadOnly()` to take a `bool`, not a `c_int`.