### PR TITLE
fix: Fix `ui.Group.SetMargined()` implementation to convert to `c_int`

### DIFF
--- a/src/ui.zig
+++ b/src/ui.zig
@@ -685,7 +685,7 @@ pub const Group = opaque {
         return uiGroupMargined(g) == 1;
     }
     pub fn SetMargined(g: *Group, margined: bool) void {
-        uiGroupSetMargined(g, margined);
+        uiGroupSetMargined(g, @intFromBool(margined));
     }
     pub fn New(title: [*:0]const u8) !*Group {
         return uiNewGroup(title) orelse error.InitGroup;


### PR DESCRIPTION
When porting the control gallery example (#14) I ran into the following build error:

```
% zig build
install
└─ install control-gallery
   └─ zig build-exe control-gallery Debug native 1 errors
src/ui.zig:688:31: error: expected type 'c_int', found 'bool'
        uiGroupSetMargined(g, margined);
                              ^~~~~~~~
src/ui.zig:678:59: note: parameter type declared here
    pub extern fn uiGroupSetMargined(g: *Group, margined: c_int) void;
                                                          ^~~~~
```

This change fixes `ui.Group.SetMargined()` to convert the `bool` correctly to a `c_int` for the call to `uiGroupSetMargined()`.