### PR TITLE
fix: Fix `ui.Slider.New()` to accept a type for `min` and `max`

### DIFF
--- a/src/ui.zig
+++ b/src/ui.zig
@@ -780,8 +780,14 @@ pub const Slider = opaque {
         uiSliderOnReleased(self, callback, userdata);
     }
     pub const SetRange = uiSliderSetRange;
-    pub fn New(min: c_int, max: c_int) !*Slider {
-        return uiNewSlider(min, max) orelse error.InitSlider;
+
+    pub const TypeEnum = union(enum) {
+        Integer: struct { min: c_int, max: c_int },
+    };
+    pub fn New(t: TypeEnum) !*Slider {
+        return switch (t) {
+            .Integer => |int| uiNewSlider(int.min, int.max),
+        } orelse error.InitSlider;
     }
 };
 


### PR DESCRIPTION
When porting the control gallery example (#14) I ran into an issue with `ui.Slider.New()`.

`ui.Spinbox.New()` defines a `TypeEnum` containing an `Integer` struct for representing the min and max values. This was missing from `ui.Slider.New()`, which accepted the values as individual arguments.

This stood out when [the two controls were used side by side in the example code](https://github.com/jthat/zig-libui-ng/blob/port-controlgallery-example/examples/control-gallery.zig#L105-L112).

Since precisely the same concept of min and max applies to both a slider and a spinbox, their API should be consistent.